### PR TITLE
Fix deprecated Animated.Text.propTypes.style which cause error

### DIFF
--- a/src/components/affix/index.js
+++ b/src/components/affix/index.js
@@ -4,7 +4,7 @@
 /* eslint-disable react/no-unused-prop-types */
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated, Text } from 'react-native';
 
 import styles from './styles';
 
@@ -28,7 +28,7 @@ export default class Affix extends PureComponent {
     baseColor: PropTypes.string.isRequired,
     animationDuration: PropTypes.number.isRequired,
 
-    style: Animated.Text.propTypes.style,
+    style: Text.propTypes.style,
 
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),

--- a/src/components/helper/index.js
+++ b/src/components/helper/index.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/default-props-match-prop-types */
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { View, Animated } from 'react-native';
+import { View, Animated, Text } from 'react-native';
 
 import styles from './styles';
 
@@ -12,7 +12,7 @@ export default class Helper extends PureComponent {
   };
 
   static propTypes = {
-    style: Animated.Text.propTypes.style,
+    style: Text.propTypes.style,
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),
       PropTypes.node,

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -4,7 +4,7 @@
 /* eslint-disable react/default-props-match-prop-types */
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated, Text } from 'react-native';
 
 export default class Label extends PureComponent {
   static defaultProps = {
@@ -33,7 +33,7 @@ export default class Label extends PureComponent {
 
     animationDuration: PropTypes.number.isRequired,
 
-    style: Animated.Text.propTypes.style,
+    style: Text.propTypes.style,
 
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),


### PR DESCRIPTION
Fix deprecated propTypes which cause error "undefined is not an object (evaluating _reactNative.Animated.Text.propTypes.style)